### PR TITLE
added 996580 profile (Spyro Reignited Trilogy)

### DIFF
--- a/gamefixes/996580
+++ b/gamefixes/996580
@@ -1,0 +1,11 @@
+""" Spyro Reignited Trilogy
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ Requires media foundation dlls
+    """
+
+    util.protontricks('mf_install')


### PR DESCRIPTION
Spyro Reignited Trilogy requires Media Foundation DLL's to run cutscenes. This will help with that.