### PR TITLE
fix ffxiv fixes

### DIFF
--- a/gamefixes/312060.py
+++ b/gamefixes/312060.py
@@ -9,9 +9,6 @@ def main():
     """ for FFXIV skip intro cutscene to allow game to work.
     """
 
-    # launcher tries to render in d3d9, d9vk doesnt work with it yet
-    util.disable_d3d9() 
-
     # disable new character intro cutscene to prevent black screen loop
     configpath = os.path.join(util.protonprefix(), 'drive_c/users/steamuser/My Documents/My Games/FINAL FANTASY XIV - A Realm Reborn')
     if not os.path.exists(configpath):

--- a/gamefixes/39210.py
+++ b/gamefixes/39210.py
@@ -9,9 +9,6 @@ def main():
     """ for FFXIV skip intro cutscene to allow game to work.
     """
 
-    # launcher tries to render in d3d9, d9vk doesnt work with it yet
-    util.disable_d3d9() 
-
     # disable new character intro cutscene to prevent black screen loop
     configpath = os.path.join(util.protonprefix(), 'drive_c/users/steamuser/My Documents/My Games/FINAL FANTASY XIV - A Realm Reborn')
     if not os.path.exists(configpath):


### PR DESCRIPTION
`util.disable_d3d9` was renamed at some point in the past. i'm not sure when this fix was ever needed anyways, so i've removed it entirely. this fixes the zenity splash hanging around forever and the other fixes not being applied.