### PR TITLE
Add fix for Dusty Revenge: Co-op Edition

### DIFF
--- a/gamefixes/252430.py
+++ b/gamefixes/252430.py
@@ -1,0 +1,11 @@
+""" Game fix for Dusty Revenge: Co-Op Edition
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ Install vcrun2010
+    """
+    util.protontricks('vcrun2010')
+    util.protontricks('dsound')


### PR DESCRIPTION
Fix for Dusty Revenge
Requires the `MF` variant of proton-ge in order to properly display videos in-game