### PR TITLE
add fix for LEGO The Lord of the Rings (214510)

### DIFF
--- a/gamefixes/214510.py
+++ b/gamefixes/214510.py
@@ -1,0 +1,11 @@
+""" Game fix for LEGO The Lord of the Rings
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ installs d3dx9_41
+    """
+
+    util.protontricks('d3dx9_41')


### PR DESCRIPTION
Tested with Proton 6.1 GE-2 on GamerOS 23.

Thanks to FigoFrago on the GamerOS discord.