### PR TITLE
klite.verb: execute the correct version

### DIFF
--- a/gamefixes/verbs/klite.verb
+++ b/gamefixes/verbs/klite.verb
@@ -40,5 +40,5 @@ hwa_other_auto=1
 lang_set_preferred=1
 lang_autodetect=1
 _EOF_
-    w_try "${WINE}" start.exe /exec K-Lite_Codec_Pack_1595_Basic.exe /verysilent /norestart /LoadInf="./klcp_basic_unattended.ini"
+    w_try "${WINE}" start.exe /exec K-Lite_Codec_Pack_1610_Basic.exe /verysilent /norestart /LoadInf="./klcp_basic_unattended.ini"
 }


### PR DESCRIPTION
The verb downloads K-Lite_Codec_Pack_1610_Basic.exe but actually tries
to run K-Lite_Codec_Pack_1595_Basic.exe resulting in an install error.