### PR TITLE
Add fix for Metro 2033

### DIFF
--- a/gamefixes/43110.py
+++ b/gamefixes/43110.py
@@ -1,0 +1,12 @@
+""" Game fix for Metro 2033
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ Installs d3dx11_42
+    """
+
+    # Fixes D3D10 and D3D11 render path crash on launch.
+    util.protontricks('d3dx11_42')


### PR DESCRIPTION
Installing `d3dx11_42` fixes D3D10 and D3D11 render path crash on launch. D3D9 is used by default, which works but D3D10 and D3D11 can be selected in video options.