### PR TITLE
Add fix for Yesterday Origins

### DIFF
--- a/gamefixes/465280.py
+++ b/gamefixes/465280.py
@@ -1,0 +1,12 @@
+""" Game fix for Yesterday Origins
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ Set to win7
+    """
+
+    # Fixes black screen during cutscenes.
+    util.protontricks('win7')


### PR DESCRIPTION
Cutscenes don't render correctly by default on Proton-6.14-GE, but they do if you change the windows version to 7. The game seems to use quartz/directshow on win7 or lower and mf on the default win10.