### PR TITLE
Online mode fix for Madden NFL 21

### DIFF
--- a/gamefixes/1239520.py
+++ b/gamefixes/1239520.py
@@ -1,0 +1,13 @@
+""" Madden NFL 21 needs vcrun2019 for online mode to work
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ 
+    """
+
+    # Replace launcher with game exe in proton arguments
+    util.protontricks('vcrun2019_ge')
+


### PR DESCRIPTION
Installing vcrun_2019 for Madden NFL 21 fixes the desync issue in online mode (head to head). Exhibition head to head with matching making and playing with friends works well.