### PR TITLE
Add Oceanhorn fix

### DIFF
--- a/gamefixes/339200.py
+++ b/gamefixes/339200.py
@@ -1,0 +1,12 @@
+""" Game fix for Oceanhorn: Monster of Uncharted Seas
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ installs d3dx10_43, d3dcompiler_43
+    """
+
+    util.protontricks('d3dx10_43')
+    util.protontricks('d3dcompiler_43')


### PR DESCRIPTION
I found that adding d3dcompiler allows the game to run.
`Oceanhorn: Monster of Uncharted Seas` (https://www.protondb.com/app/339200/)

~~I suppose this should be enough for the game to run on fresh versions of Wine.~~
(I mean I don't have the version of the game on Steam to check it out in Proton-GE)
<details><summary>I have the GOG-version only</summary>
<p>

![Oceanhorn_gog](https://user-images.githubusercontent.com/25866099/144149711-2a2b50de-eada-420c-8392-b740ef998f3f.png)

</p>
</details>

The game starts successfully with Fsync (version for working with kernel-5.16)
<details><summary>some game screenshots</summary>
<p>

![Oceanhorn_screenshot1](https://user-images.githubusercontent.com/25866099/144147579-46f3bcdb-f4ab-43e0-8b7d-72671f7dfe14.png)
![Oceanhorn_screenshot2](https://user-images.githubusercontent.com/25866099/144147588-56b837af-bf02-4e9d-b973-4da88c01e5a1.png)

</p>
</details>

UPD. I made more checks and found that `d3dx10_43` seems required for fixing some fonts problem - however, this does not seem to fix the problem for all languages. I did the PR update for the better solution.