### PR TITLE
Fix for LEGO Batman 2: DC Super Heroes

### DIFF
--- a/gamefixes/213330.py
+++ b/gamefixes/213330.py
@@ -1,0 +1,11 @@
+""" Game fix for LEGO Batman 2: DC Super Heroes
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ installs d3dx9_41
+    """
+
+    util.protontricks('d3dx9_41') 


### PR DESCRIPTION
Installs d3dx9_41
Successfully tested with Proton-7.0rc2-GE-1.