### PR TITLE
Add fix for Super Meat Boy

### DIFF
--- a/gamefixes/40800.py
+++ b/gamefixes/40800.py
@@ -1,0 +1,12 @@
+""" Game fix Super Meat Boy
+"""
+#pylint: disable=C0103
+#
+from protonfixes import util
+
+def main():
+    """ installs d3dcompiler, xact
+    """
+
+    util.protontricks('d3dcompiler_47')
+    util.protontricks('xact')

--- a/gamefixes/40800.py
+++ b/gamefixes/40800.py
@@ -1,4 +1,4 @@
-""" Game fix Super Meat Boy
+""" Game fix for Super Meat Boy
 """
 #pylint: disable=C0103
 #


### PR DESCRIPTION
This will allow for access to version 1.2.5, which contains various bug fixes, a fixed Super Meat World, and the 2015 soundtrack as an option.