### PR TITLE
Use SteamGameId if SteamAppId is zero

### DIFF
--- a/fix.py
+++ b/fix.py
@@ -16,7 +16,7 @@ def game_id():
     """ Trys to return the game id from environment variables
     """
 
-    if 'SteamAppId' in os.environ:
+    if 'SteamAppId' in os.environ and os.environ['SteamAppId'] != '0':
         return os.environ['SteamAppId']
     if 'SteamGameId' in os.environ:
         return os.environ['SteamGameId']


### PR DESCRIPTION
***Context:** I'm currently developing a workflow for more easily running non-Steam games through Steam with Proton, in order to facilitate the use of Steam features (e.g. the overlay and controller mapping support) in games that are not in the Steam catalogue. This is particularly useful for older games (and mods built on older games) that lack controller support and would benefit from Steam's controller remapping functionality, but cannot access this from standalone Wine or Proton prefixes. My intention is to use protonfixes to make it easier and more repeatable to install the required dependencies for these games.*

When Steam runs a non-Steam game shortcut using Proton, the `SteamAppId` environment variable is set to zero, and the `SteamGameId` environment variable is set to a hash of the shortcut name (i.e. renaming a shortcut will change the `SteamGameId` value, but the value will always be the same for any given shortcut name.) The current protonfixes startup logic will search for fixes based on the `SteamAppId` value so long as that environment variable is present, even if the value is zero. This means users can create a fix for a non-Steam shortcut by creating a file called `~/.config/protonfixes/localfixes/0.py`, but they are limited to a single fix file since all shortcuts will be treated as having an ID value of zero.

Although it's certainly possible to create one large Python script that reads the `SteamGameId` environment variable and performs logic based on the value, a far more user-friendly approach is to have protonfixes use the `SteamGameId` value if the `SteamAppId` value is zero, which allows users to create individual fix scripts for each different shortcut. This makes it much easier to share fix scripts with other community members once they have been created and tested. This pull request implements the necessary changes to the protonfixes startup logic.

***Note:** users will of course need to determine the correct ID value for a given shortcut name, but I've implemented a small executable that they can set as the initial shortcut target which will read the environment variable, create a boilerplate fix file with the appropriate filename, and report the ID number so they know which file to edit and subsequently share with others.*