### PR TITLE
klite: update version

### DIFF
--- a/gamefixes/verbs/klite.verb
+++ b/gamefixes/verbs/klite.verb
@@ -1,12 +1,12 @@
 w_metadata klite dlls \
     title="K-Lite codecs" \
     media="download" \
-    file1="K-Lite_Codec_Pack_1646_Basic.exe" \
+    file1="K-Lite_Codec_Pack_1670_Basic.exe" \
     homepage="https://codecguide.com/download_kl.htm"
 
 load_klite()
 {
-    w_download https://files3.codecguide.com/K-Lite_Codec_Pack_1646_Basic.exe 5e338c103f9b3f9cd38d56079796a92a98b5d5142e05829891e9ffbb89bf1f4b
+    w_download https://files3.codecguide.com/K-Lite_Codec_Pack_1670_Basic.exe 92a60f69e33b75999c524cc1333166172e2b7ebd7fbd12fadc420dfc3dc096aa
     w_try_cd "${W_CACHE}/${W_PACKAGE}"
     cat > "klcp_basic_unattended.ini" <<_EOF_
 [Setup]
@@ -40,5 +40,5 @@ hwa_other_auto=1
 lang_set_preferred=1
 lang_autodetect=1
 _EOF_
-    w_try "${WINE}" start.exe /exec K-Lite_Codec_Pack_1646_Basic.exe /verysilent /norestart /LoadInf="./klcp_basic_unattended.ini"
+    w_try "${WINE}" start.exe /exec K-Lite_Codec_Pack_1670_Basic.exe /verysilent /norestart /LoadInf="./klcp_basic_unattended.ini"
 }


### PR DESCRIPTION
Gave it a quick test run with a fresh Persona 4 Golden prefix (Proton-7.0rc6-GE-1) and clean winetricks cache directory. Everything installed fine and the error about registering `C:\Program Files (x86)\K-Lite Codec Pack\Icaros\{32,64}-bit\IcarosThumbnailProvider.dll - Unable to register the DLL/OCX: RegSvr32 failed with exit code 0x3` that happened starting with Proton-GE-6.20 are also gone, probably fixed by recent Proton/Wine changes and not related to the actual codec version. Game intro and in-game videos are playing fine.