### PR TITLE
add fix for IMSCARED

### DIFF
--- a/gamefixes/429720.py
+++ b/gamefixes/429720.py
@@ -1,0 +1,23 @@
+""" Game fix for IMSCARED
+"""
+
+#pylint: disable=C0103
+
+from protonfixes import util
+import os
+import getpass
+
+# IMSCARED relies on a folder on the user's Desktop being accessible
+# The problem is that all of the folders in Proton are sandboxed
+# So this protonfix works around that
+def main():
+    desktoppath = os.path.join(util.protonprefix(), 'drive_c/users/steamuser/Desktop')
+    if os.path.exists(desktoppath):
+        if os.path.islink(desktoppath):
+    	    os.unlink(desktoppath)
+        else:
+    	    os.rmdir(desktoppath)
+    dst = '/home/' + getpass.getuser() + '/Desktop/'
+    os.symlink(dst, desktoppath)
+	
+


### PR DESCRIPTION
IMSCARED relies on a folder being accessible on the user's desktop to play correctly.
However, Proton sandboxes all user folders, which breaks this game.
This fix just works around that by creating a symbolic link in `steamuser` to the user's desktop.

![Screenshot_20220212_153932](https://user-images.githubusercontent.com/34801996/153732073-15c5fc38-9d38-4530-8d02-88a560572cee.png)
