### PR TITLE
Add fix for Watch_Dogs

### DIFF
--- a/gamefixes/243470.py
+++ b/gamefixes/243470.py
@@ -1,0 +1,13 @@
+""" Game fix for Watch_Dogs
+"""
+
+#pylint: disable=C0103
+
+from protonfixes import util
+import os
+
+# Watch_Dogs crashes if we don't force xaudio2_7 to native.
+# Forcing watch_dogs.exe to run as Windows XP x64 allows for sound effects to work correctly.
+def main():
+    util.regedit_add("HKCU\\Software\\Wine\\AppDefaults\\watch_dogs.exe",'Version','REG_SZ','winxp64')
+    util.winedll_override('xaudio2_7', 'n')


### PR DESCRIPTION
Watch_Dogs crashes unless `xaudio2_7` is forced to native.
However, this breaks the game's sound effects, so we must also force the game executable to be run as Windows XP x64.
We can't do this globally, however, as it breaks Ubisoft Connect.