### PR TITLE
Make Batman Arkham Knight use NVIDIA PhysX

### DIFF
--- a/gamefixes/208650.py
+++ b/gamefixes/208650.py
@@ -1,0 +1,12 @@
+""" Game fix for Batman Arkham Knight
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ NVIDIA PhysX support.
+    """
+
+    # Enables NVIDIA PhysX in Batman Arkham Knight.
+    util.protontricks('physx')

--- a/winetricks
+++ b/winetricks
@@ -11580,16 +11580,23 @@ load_peverify()
 w_metadata physx dlls \
     title="PhysX" \
     publisher="Nvidia" \
-    year="2019" \
+    year="2021" \
     media="download" \
-    file1="PhysX-9.19.0218-SystemSoftware.exe" \
-    installed_file1="${W_PROGRAMS_X86_WIN}/NVIDIA Corporation/PhysX/Engine/86C5F4F22ECD/APEX_Particles_x64.dll"
+    file1="PhysX_9.21.0713_SystemSoftware.exe" \
 
 load_physx()
 {
-    w_download https://uk.download.nvidia.com/Windows/9.19.0218/PhysX-9.19.0218-SystemSoftware.exe 4f36389fcbfbdef4781fb85e7a68373542903235f65d93f7143693738324917c
-    w_try_cd "${W_CACHE}/${W_PACKAGE}"
-    w_try "${WINE}" PhysX-9.19.0218-SystemSoftware.exe ${W_OPT_UNATTENDED:+/s}
+    w_get_sha256sum "${W_PROGRAMS_X86_UNIX}/NVIDIA Corporation/PhysX/Engine/86C5F4F22ECD/APEX_Particles_x64.dll"
+    if [ "${_W_gotsha256sum}"x = "b3991e0165a9802b60e2f7d14c1be5f879071999ae74a38263cec9bf043a9eaa"x ] ; then
+        w_warn "${W_PACKAGE} is already installed - not updating"
+        unset _W_gotsha256sum
+        return
+    else
+        unset _W_gotsha256sum
+        w_download https://us.download.nvidia.com/Windows/9.21.0713/PhysX_9.21.0713_SystemSoftware.exe 26d62c5c347c15cb27c3be92bf10706113511b48b28aecc09f61ee58b3b62778
+        w_try_cd "${W_CACHE}/${W_PACKAGE}"
+        w_try "${WINE}" PhysX_9.21.0713_SystemSoftware.exe ${W_OPT_UNATTENDED:+/s}
+    fi
 }
 
 #----------------------------------------------------------------


### PR DESCRIPTION
With recent DXVK-NVAPI changes and upstream staging nvCUDA patches, Batman Arkham Knight can now use NVIDIA PhysX for FOG and DEBRIS.

This gets latest PhysX version, and install PhysX for Batman Arkham Knight (208650)