### PR TITLE
244850: Remove unnecessary dotnet48 winetricks

### DIFF
--- a/gamefixes/244850.py
+++ b/gamefixes/244850.py
@@ -15,6 +15,4 @@ def main():
 
     util.set_xml_options(base_attibutte, game_opts, 'SpaceEngineers.exe.config','game')
 
-    # This requires Proton 5.0 installed
-    util.protontricks_proton_5('dotnet48')
     util.append_argument('-skipintro')


### PR DESCRIPTION
Devs released compatibility with wine-mono recently. Forcing dotnet48 to install gets in the way of testing that. This should be optional and handled manually now.