### PR TITLE
Add Protonfix for Heavy Rain (960910)

### DIFF
--- a/gamefixes/960910.py
+++ b/gamefixes/960910.py
@@ -1,0 +1,11 @@
+""" Game fix for Heavy Rain
+"""
+
+#pylint: disable=C0103
+
+from protonfixes import util
+import os
+
+# Heavy Rain has broken lip-syncing unless xaudio2_7 is forced to native.
+def main():
+    util.winedll_override('xaudio2_7', 'n')


### PR DESCRIPTION
Heavy Rain has lip-syncing functionality that is broken unless `xaudio2_7` is forced to native.
This performs that fix so that it works correctly.
![image](https://user-images.githubusercontent.com/34801996/154215415-2c9c0498-b0a0-4d92-82e0-889cd7e0abc9.png)
