### PR TITLE
Add game fix for Putt-Putt: Pep's Birthday Surprise (294700)

### DIFF
--- a/gamefixes/294700.py
+++ b/gamefixes/294700.py
@@ -1,0 +1,17 @@
+""" Game fix for Putt-Putt: Pep's Birthday Surprise
+"""
+
+#pylint: disable=C0103
+
+from protonfixes import util
+import os
+
+# Putt-Putt: PBS doesn't run unless there is a CD-ROM drive attached.
+def main():
+    dosdevice = os.path.join(util.protonprefix(), 'dosdevices/r:')
+    if not os.path.exists(dosdevice):
+        os.symlink('/mnt', dosdevice) #create symlink for dosdevices
+
+    util.regedit_add("HKLM\\System\\MountedDevices",'\\??\\Volume{00000000-0000-0000-0000-000000000052}','REG_BINARY','2f6d6e7400') #sets up ID? exported from regedit
+    util.regedit_add("HKLM\\System\\MountedDevices",'\\DosDevices\\R:','REG_BINARY','5c005c002e005c0064003a000000') #sets up dosdevice? exported from regedit
+    util.regedit_add("HKLM\\Software\\Wine\\Drives",'r:','REG_SZ','cdrom', 1) #designate drive as CD-ROM, requires 64-bit access

--- a/gamefixes/294700.py
+++ b/gamefixes/294700.py
@@ -10,7 +10,7 @@ import os
 def main():
     dosdevice = os.path.join(util.protonprefix(), 'dosdevices/r:')
     if not os.path.exists(dosdevice):
-        os.symlink('/mnt', dosdevice) #create symlink for dosdevices
+        os.symlink('/tmp', dosdevice) #create symlink for dosdevices
 
     util.regedit_add("HKLM\\System\\MountedDevices",'\\??\\Volume{00000000-0000-0000-0000-000000000052}','REG_BINARY','2f746d7000') #sets up ID? exported from regedit
     util.regedit_add("HKLM\\System\\MountedDevices",'\\DosDevices\\R:','REG_BINARY','5c005c002e005c0064003a000000') #sets up dosdevice? exported from regedit

--- a/gamefixes/294700.py
+++ b/gamefixes/294700.py
@@ -12,6 +12,6 @@ def main():
     if not os.path.exists(dosdevice):
         os.symlink('/mnt', dosdevice) #create symlink for dosdevices
 
-    util.regedit_add("HKLM\\System\\MountedDevices",'\\??\\Volume{00000000-0000-0000-0000-000000000052}','REG_BINARY','2f6d6e7400') #sets up ID? exported from regedit
+    util.regedit_add("HKLM\\System\\MountedDevices",'\\??\\Volume{00000000-0000-0000-0000-000000000052}','REG_BINARY','2f746d7000') #sets up ID? exported from regedit
     util.regedit_add("HKLM\\System\\MountedDevices",'\\DosDevices\\R:','REG_BINARY','5c005c002e005c0064003a000000') #sets up dosdevice? exported from regedit
     util.regedit_add("HKLM\\Software\\Wine\\Drives",'r:','REG_SZ','cdrom', 1) #designate drive as CD-ROM, requires 64-bit access

--- a/util.py
+++ b/util.py
@@ -315,11 +315,6 @@ def protontricks_proton_5(verb):
         process = subprocess.Popen(winetricks_cmd, env=env)
         process.wait()
 
-def regedit_determineArch(var):
-    if var is not None and type(var) == int:
-        return '/reg:64'
-    return ''
-
 def regedit_add(folder,name=None,type=None,value=None,arch=None):
     """ Add regedit keys
     """
@@ -332,12 +327,23 @@ def regedit_add(folder,name=None,type=None,value=None,arch=None):
     
     if name is not None and type is not None and value is not None:
 
-        regedit_cmd = ['wine', 'reg' , 'add', folder, '/f', '/v', name, '/t', type, '/d', value, regedit_determineArch(arch)]
+        # Flag for if we want to force writing to the 64-bit registry sector
+        if arch is not None:
+            regedit_cmd = ['wine', 'reg' , 'add', folder, '/f', '/v', name, '/t', type, '/d', value, '/reg:64']
+        else:
+            regedit_cmd = ['wine', 'reg' , 'add', folder, '/f', '/v', name, '/t', type, '/d', value]
+
         log.info('Adding key: ' + folder)
 
     else:
 
-        regedit_cmd = ['wine', 'reg' , 'add', folder, '/f', regedit_determineArch(name)]
+        # Flag for if we want to force writing to the 64-bit registry sector
+        # We use name here because without the other flags we can't use the arch flag
+        if name is not None:
+            regedit_cmd = ['wine', 'reg' , 'add', folder, '/f', '/reg:64']
+        else:
+            regedit_cmd = ['wine', 'reg' , 'add', folder, '/f']
+
         log.info('Adding key: ' + folder)
 
     process = subprocess.Popen(regedit_cmd, env=env)

--- a/util.py
+++ b/util.py
@@ -315,6 +315,11 @@ def protontricks_proton_5(verb):
         process = subprocess.Popen(winetricks_cmd, env=env)
         process.wait()
 
+def regedit_determineArch(var):
+    if var is not None and type(var) == int:
+        return '/reg:64'
+    return ''
+
 def regedit_add(folder,name=None,type=None,value=None,arch=None):
     """ Add regedit keys
     """
@@ -325,20 +330,14 @@ def regedit_add(folder,name=None,type=None,value=None,arch=None):
     env['WINELOADER'] = protonmain.g_proton.wine_bin
     env['WINESERVER'] = protonmain.g_proton.wineserver_bin
     
-    # Flag for if we want to force writing to the 64-bit registry sector
-    if arch is not None:
-        arch = '/reg:64'
-    else:
-        arch = ''
-    
     if name is not None and type is not None and value is not None:
 
-        regedit_cmd = ['wine', 'reg' , 'add', folder, '/f', '/v', name, '/t', type, '/d', value, arch]
+        regedit_cmd = ['wine', 'reg' , 'add', folder, '/f', '/v', name, '/t', type, '/d', value, regedit_determineArch(arch)]
         log.info('Adding key: ' + folder)
 
     else:
 
-        regedit_cmd = ['wine', 'reg' , 'add', folder, '/f', arch]
+        regedit_cmd = ['wine', 'reg' , 'add', folder, '/f', regedit_determineArch(name)]
         log.info('Adding key: ' + folder)
 
     process = subprocess.Popen(regedit_cmd, env=env)

--- a/util.py
+++ b/util.py
@@ -338,7 +338,7 @@ def regedit_add(folder,name=None,type=None,value=None,arch=None):
 
     else:
 
-        regedit_cmd = ['wine', 'reg' , 'add', folder, '/f']
+        regedit_cmd = ['wine', 'reg' , 'add', folder, '/f', arch]
         log.info('Adding key: ' + folder)
 
     process = subprocess.Popen(regedit_cmd, env=env)

--- a/util.py
+++ b/util.py
@@ -315,7 +315,7 @@ def protontricks_proton_5(verb):
         process = subprocess.Popen(winetricks_cmd, env=env)
         process.wait()
 
-def regedit_add(folder,name=None,type=None,value=None):
+def regedit_add(folder,name=None,type=None,value=None,arch=None):
     """ Add regedit keys
     """
 
@@ -325,9 +325,15 @@ def regedit_add(folder,name=None,type=None,value=None):
     env['WINELOADER'] = protonmain.g_proton.wine_bin
     env['WINESERVER'] = protonmain.g_proton.wineserver_bin
     
+    # Flag for if we want to force writing to the 64-bit registry sector
+    if arch is not None:
+        arch = '/reg:64'
+    else:
+        arch = ''
+    
     if name is not None and type is not None and value is not None:
 
-        regedit_cmd = ['wine', 'reg' , 'add', folder, '/f', '/v', name, '/t', type, '/d', value]
+        regedit_cmd = ['wine', 'reg' , 'add', folder, '/f', '/v', name, '/t', type, '/d', value, arch]
         log.info('Adding key: ' + folder)
 
     else:


### PR DESCRIPTION
Putt-Putt: Pep's Birthday Surprise relies on a CD-ROM drive being attached at any mount point.
This fix uses the registry to replicate what `winecfg` does for its Drives menu, and attaches one at `R:`.
It also adds an optional flag to `util.regedit_add` that will allow for the usage of the `/reg:64` flag to force `reg.exe` to write to the 64-bit registry partition. (Thanks Josh for pointing this out! 🐸)

![image](https://user-images.githubusercontent.com/34801996/154389985-632ca968-9126-4e35-8b70-fa4bcf774a14.png)
