### PR TITLE
BG3: Remove launcher skip to allow Vulkan/DX11 selection

### DIFF
--- a/gamefixes/1086940.py
+++ b/gamefixes/1086940.py
@@ -10,4 +10,3 @@ def main():
     # Fixes the startup process.
     util.protontricks('vcrun2019_ge')
     util.protontricks('d3dcompiler_47')
-    util.replace_command('LariLauncher.exe', '../bin/bg3.exe')


### PR DESCRIPTION
Launcher is stable as of game Patch 6 & 7. Vulkan renderer
shows frequent breakage on latest updates. Currently AMDGPU (RADV)
shows heavy flicker for Vulkan overlays on Vulkan renderer.
DX11 is a proven stable alternative for BG3.
Choosing DX11 is difficult today due to the replace_command protonfix.

Keep vcrun2019_ge as it still fixes the VC++ runtime crashes during
gameplay.

Not sure where d3dcompiler_47 dependency is coming from, so
let's keep it as well.