### PR TITLE
force dx11 for la noire by launch option

### DIFF
--- a/gamefixes/110800.py
+++ b/gamefixes/110800.py
@@ -6,6 +6,7 @@ from protonfixes import util
 
 def main():
     """ installs d3dx9_43, d3dcompiler_43, d3dx11_43, d3dcompiler_47
+        forces dx11 (enables intro cinematics) without editing settings.ini
     """
 
     # https://github.com/ValveSoftware/Proton/issues/544#issuecomment-826150012
@@ -13,3 +14,4 @@ def main():
     util.protontricks('d3dcompiler_43')
     util.protontricks('d3dx11_43')
     util.protontricks('d3dcompiler_47')
+    util.append_argument('-dx11')


### PR DESCRIPTION
la noire defaults to dx9 in it's settings.ini