### PR TITLE
Add protonfix for Sid Meier's Civilization IV: Beyond the Sword

### DIFF
--- a/gamefixes/8800.py
+++ b/gamefixes/8800.py
@@ -9,4 +9,5 @@ def main():
 
     util.protontricks('msxml3')
     util.protontricks('corefonts')
-
+    util.disable_dxvk()
+    

--- a/gamefixes/8800.py
+++ b/gamefixes/8800.py
@@ -1,0 +1,12 @@
+""" Sid Meier's Civilization IV: Beyond the Sword
+"""
+
+# Note: as of 2022-mar-07 buttons glitchy unless using PROTON_USE_WINED3D=1 environment
+
+from protonfixes import util
+
+def main():
+
+    util.protontricks('msxml3')
+    util.protontricks('corefonts')
+


### PR DESCRIPTION
As suggested by btegs [here](https://github.com/GloriousEggroll/protonfixes/commit/6f9354686142b9d79689fa421a05c3cb6be36b48#commitcomment-68084437), I also added a protonfix for Civ4BTS. 
Note that this one needs PROTON_USE_WINED3D=1, I could not find out if there is a protonfix command to add this automatically to the environment ...