### PR TITLE
Add option to launch XIVLauncher

### DIFF
--- a/gamefixes/39210.py
+++ b/gamefixes/39210.py
@@ -11,3 +11,10 @@ def main():
     # Fixes the startup process.
     if 'NOSTEAM' in os.environ:
         util.replace_command('-issteam', '')
+    
+    # Runs XIVLauncher instead of Stock Launcher
+    if 'XL_WINEONLINUX' in os.environ:
+        util.protontricks_proton_5('dotnet48')
+        util.protontricks('vcrun2019')
+        util.replace_command('common/FINAL FANTASY XIV Online/boot/ffxivboot.exe', 'compatdata/39210/pfx/drive_c/users/steamuser/AppData/Local/XIVLauncher/XIVLauncher.exe')
+        util.replace_command('-issteam', '')

--- a/gamefixes/39210.py
+++ b/gamefixes/39210.py
@@ -14,6 +14,7 @@ def main():
     
     # Runs XIVLauncher instead of Stock Launcher
     if 'XL_WINEONLINUX' in os.environ:
+        util.set_environment('PROTON_SET_GAME_DRIVE', '1')
         util.protontricks_proton_5('dotnet48')
         util.protontricks('vcrun2019')
         util.replace_command('common/FINAL FANTASY XIV Online/boot/ffxivboot.exe', 'compatdata/39210/pfx/drive_c/users/steamuser/AppData/Local/XIVLauncher/XIVLauncher.exe')


### PR DESCRIPTION
Using protontricks to install requirements for XIVLauncher. XIVLauncher still needs to be manually downloaded and installed with protontricks 39210 run.

XL_WINEONLINUX is already used by XIVLauncher to run in with full priviledges in Wine.