### PR TITLE
Fixed Typo(s) with 39140 Inheriting 1113000 Text

### DIFF
--- a/gamefixes/39140.py
+++ b/gamefixes/39140.py
@@ -1,14 +1,14 @@
-""" Game fix for Persona 4 Golden
+""" Game fix for Final Fantasy VII
 """
 #pylint: disable=C0103
 
 from protonfixes import util
 
 def main():
-    """ installs devenum, quartz, wmp9 and adjust pulse latency
+    """ installs vcrun2019_ge and d3dcompiler47                
     """
 
-    # Fix pre-rendered cutscene playback
+    # FFVII needs vcrun2019 and d3dcompiler_47
     util.protontricks('vcrun2019_ge')
     util.protontricks('d3dcompiler_47')
 

--- a/gamefixes/495420.py
+++ b/gamefixes/495420.py
@@ -1,0 +1,13 @@
+""" Game fix for State of Decay 2
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ Fix game crashes with d3dcompiler_47 and multiplayer crashes with win7
+    """
+
+    util.protontricks('d3dcompiler_47')
+    util.protontricks('win7')
+


### PR DESCRIPTION
A commit to 39140.py inherited 1113000.py's references to Persona 4 Golden, video playback, and other unused protontricks verbs; this commit corrects these inconsistencies.