### PR TITLE
Force EAC runtime install on FallGuys

### DIFF
--- a/gamefixes/1097150.py
+++ b/gamefixes/1097150.py
@@ -3,10 +3,13 @@
 #pylint: disable=C0103
 import os
 import subprocess
+from protonfixes import util
 
 def main():
     """ Create symlink of eac so at the right location
     """
+    util.install_eac_runtime()
+    
     if os.path.exists('FallGuys_client_game_Data/Plugins/x86_64/easyanticheat_x64.so'):
         subprocess.call(['rm', '-rf', 'FallGuys_client_game_Data/Plugins/x86_64/easyanticheat_x64.so'])
     subprocess.call(['ln', '-s', '../../../EasyAntiCheat/easyanticheat_x64.so', 'FallGuys_client_game_Data/Plugins/x86_64/easyanticheat_x64.so'])

--- a/steamhelper.py
+++ b/steamhelper.py
@@ -1,0 +1,87 @@
+import os
+import re
+import shutil
+import subprocess
+import time
+
+libpaths = []
+REGEX_LIB = re.compile(r'"path"\s*"(?P<path>(.*))"')
+REGEX_STATE = re.compile(r'"StateFlags"\s*"(?P<state>(\d))"')
+
+def install_app(appid, delay=1):
+    """Wait for the installation of an appid
+    """
+    _install_steam_appid(appid)
+    while not(_is_app_installed(appid)):
+        time.sleep(delay)
+
+def _install_steam_appid(appid):
+    """ Call steam URL
+    """
+    install_url = "steam://install/"+str(appid)
+    if shutil.which("xdg-open"):
+        subprocess.call(["xdg-open", install_url])
+    elif shutil.which("gvfs-open"):
+        subprocess.call(["gvfs-open", install_url])
+    elif shutil.which("gnome-open"):
+        subprocess.call(["gnome-open", install_url])
+    elif shutil.which("kde-open"):
+        subprocess.call(["kde-open", install_url])
+    elif shutil.which("exo-open"):
+        subprocess.call(["exo-open", install_url])
+
+def _is_app_installed(appid):
+    """Check if app is installed
+    """
+    libraries_path = _get_steam_libraries_path()
+    
+    # bypass no library path
+    if len(libraries_path) == 0:
+        return True
+
+    is_installed = False
+    for librarypath in libraries_path:
+        appmanifest_path = _get_manifest_path(appid, librarypath)
+        if os.path.exists(appmanifest_path):
+            state = _find_regex_groups(appmanifest_path, REGEX_STATE, 'state')
+            if(len(state)>0 and int(state[0])==4):
+                is_installed = True
+            break
+    return is_installed
+
+def _get_steam_libraries_path():
+    """Get Steam Libraries Path
+    """ 
+    STEAM_DIRS = [
+        "~/.steam/root", 
+        "~/.steam/debian-installation", 
+        "~/.local/share/Steam", 
+        "~/.steam/steam"
+    ]
+    
+    global libpaths
+    if len(libpaths) == 0:
+        for steampath in STEAM_DIRS:
+            libfile = os.path.join(os.path.expanduser(steampath),"steamapps","libraryfolders.vdf")
+            if os.path.exists(libfile):
+                libpaths = _find_regex_groups(libfile, REGEX_LIB, 'path')
+                break
+    return libpaths
+
+
+def _get_manifest_path(appid, librarypath):
+    """Get appmanifest path
+    """
+    return os.path.join(librarypath, "steamapps", "appmanifest_"+str(appid)+".acf")
+
+def _find_regex_groups(path, regex, groupname):
+    """ Given a file and a regex with a named group groupname, return an
+        array of all the matches
+    """
+    matches = []
+    with open(path) as re_file:
+        for line in re_file:
+            search = regex.search(line)
+            if search:
+                matches.append(search.group(groupname))
+    return matches

--- a/util.py
+++ b/util.py
@@ -12,6 +12,7 @@ import subprocess
 import urllib.request
 import functools
 from .logger import log
+from .steamhelper import install_app
 from . import config
 
 try:
@@ -612,6 +613,16 @@ def set_dxvk_option(opt, val, cfile='/tmp/protonfixes_dxvk.conf'):
     with open(cfile, 'w') as configfile:
         conf.write(configfile)
 
+def install_eac_runtime():
+    """ Install Proton Easyanticheat Runtime
+    """
+    install_app(1826330)
+
+def install_battleye_runtime():
+    """ Install Proton BattlEye Runtime
+    """
+    install_app(1161040)
+        
 def install_from_zip(url, filename, path=os.getcwd()):
     """ Install a file from a downloaded zip
     """


### PR DESCRIPTION
Some people are complaining about the FallGuys fix not working out of the box. Most of the issues are related to not have the Proton EAC Runtime tool installed.
With this, when launching the game, a install popup will be shown and the protonfix will wait for the complete installation of the tool.
![image](https://user-images.githubusercontent.com/2856518/170580043-8c907e66-bd03-4469-8735-a95429f03154.png)

The user can choose to install or not, although the game will wait for the installation of the tool.
Also, the user can force close the game, killing protonfixes script.
![image](https://user-images.githubusercontent.com/2856518/170580170-2c787005-ad34-4d4f-a02f-cc84fa1246a8.png)
