### PR TITLE
Fix Total War Rome II

### DIFF
--- a/gamefixes/214950.py
+++ b/gamefixes/214950.py
@@ -1,0 +1,16 @@
+""" Game fix for Total War: Rome II
+"""
+
+from protonfixes import util
+
+def main():
+    """ installs d3dx11_42, d3dcompliler_42, directplay
+        Disable esync and fsync
+    """
+
+    util.protontricks('d3dx11_42')
+    util.protontricks('d3dcompliler_42')
+    util.protontricks('directplay')
+    
+    util.disable_esync()
+    util.disable_fsync()

--- a/gamefixes/214950.py
+++ b/gamefixes/214950.py
@@ -4,12 +4,12 @@
 from protonfixes import util
 
 def main():
-    """ installs d3dx11_42, d3dcompliler_42, directplay
+    """ installs d3dx11_42, d3dcompiler_42, directplay
         Disable esync and fsync
     """
 
     util.protontricks('d3dx11_42')
-    util.protontricks('d3dcompliler_42')
+    util.protontricks('d3dcompiler_42')
     util.protontricks('directplay')
     
     util.disable_esync()


### PR DESCRIPTION
Per my comment here, this fixes all crashes with the game. Without disabling esync/fsync there are access violations that cause the game to crash.  Without adding protontricks the game can also crash.  Directplay seems to potentially be necessary for multiplayer.

https://www.protondb.com/app/214950#PdN8hrzBYd