### PR TITLE
Add mfc140 to Gwent to allow game startup

### DIFF
--- a/gamefixes/1284410.py
+++ b/gamefixes/1284410.py
@@ -1,0 +1,16 @@
+""" GWENT: The Witcher Card Game
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ installs mfc140
+
+    mfc140 is necessary to start the game up. GOG login happens inside the Steam overlay.
+
+    vcrun2019_ge enables full support of the prelauncher interface. GOG login inside the prelauncher.
+    This prelauncher is not necessary for the Game. If only mfc is present, it's skipped.
+    """
+
+    util.protontricks('mfc140')


### PR DESCRIPTION
Recently Gwent requires `mfc140` to be available for the `prelauncher` in order to startup ([ProtonDB](https://www.protondb.com/app/1284410)). 

Although it then still complains about missing components like `MSVCP140_ATOMIC_WAIT.dll` in `/tmp/proton_crashreports`, it fully starts up. If the additional components are installed using `vcrun2019_ge` verb, the prelauncher is also visible and no further error are shown.

However the prelauncher appears to be only an annoyance as the GOG login still works without it. 