### PR TITLE
Fixed a launch error preventing the game from running due to missing …

### DIFF
--- a/gamefixes/213610.py
+++ b/gamefixes/213610.py
@@ -1,0 +1,14 @@
+""" Sonic Adventure 2
+"""
+#pylint: disable=C0103
+
+import os
+import shutil
+import subprocess
+from protonfixes import util
+
+def main():
+    """ Fix the hyper speed issue when the framerate is over 60.
+    """
+
+    util.set_environment('DXVK_FRAME_RATE', '60')

--- a/gamefixes/21680.py
+++ b/gamefixes/21680.py
@@ -1,0 +1,15 @@
+""" Bionic Commander Rearmed
+"""
+#pylint: disable=C0103
+
+import os
+import shutil
+import subprocess
+from protonfixes import util
+
+def main():
+    """ Installs physx
+    """
+    util.protontricks('physx')
+
+


### PR DESCRIPTION
[Bionic Commander Rearmed] Adding physx was all that was needed to get this game to run and be playable, although there are some audio issues at the titlescreen.

[Sonic Adventure 2] Limiting the framerate to 60 is needed to prevent the game from running way to fast on high refresh rate monitors.