### PR TITLE
klite: update version

### DIFF
--- a/gamefixes/verbs/klite.verb
+++ b/gamefixes/verbs/klite.verb
@@ -1,12 +1,12 @@
 w_metadata klite dlls \
     title="K-Lite codecs" \
     media="download" \
-    file1="K-Lite_Codec_Pack_1670_Basic.exe" \
+    file1="K-Lite_Codec_Pack_1700_Basic.exe" \
     homepage="https://codecguide.com/download_kl.htm"
 
 load_klite()
 {
-    w_download https://files3.codecguide.com/K-Lite_Codec_Pack_1670_Basic.exe 92a60f69e33b75999c524cc1333166172e2b7ebd7fbd12fadc420dfc3dc096aa
+    w_download https://files3.codecguide.com/K-Lite_Codec_Pack_1700_Basic.exe 24ffa374926004d3b7e8e0a3daa2d0f7f18846c8bcbcbddf8af38a7f9a0fb629
     w_try_cd "${W_CACHE}/${W_PACKAGE}"
     cat > "klcp_basic_unattended.ini" <<_EOF_
 [Setup]
@@ -40,5 +40,5 @@ hwa_other_auto=1
 lang_set_preferred=1
 lang_autodetect=1
 _EOF_
-    w_try "${WINE}" start.exe /exec K-Lite_Codec_Pack_1670_Basic.exe /verysilent /norestart /LoadInf="./klcp_basic_unattended.ini"
+    w_try "${WINE}" start.exe /exec K-Lite_Codec_Pack_1700_Basic.exe /verysilent /norestart /LoadInf="./klcp_basic_unattended.ini"
 }


### PR DESCRIPTION
Gave it a quick test run with a fresh Persona 4 Golden prefix replacing the klite.verb shipped with GE-Proton7-20 with the modified one.