### PR TITLE
Sword Of the Stars needs d3dx9 per winehq, protondb, etc

### DIFF
--- a/gamefixes/42890.py
+++ b/gamefixes/42890.py
@@ -1,0 +1,9 @@
+""" Game fix for Sword Of the Stars Complete Collection
+"""
+
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    util.protontricks('d3dx9')


### PR DESCRIPTION
First time adding one of these, based it off of what other similar fixes requiring `d3dx9` do.

Tested by manually putting the file in for `GE-Proton7-24/protonfixes/gamefixes/42890.py`

So, at least works on my machine(tm)? Let me know if I did this wrong and it needs to be elsewhere.

Supersedes my previous methods of using `flatpak run com.github.Matoking.protontricks 42890 d3dx9` :)