### PR TITLE
Add fix for Rebel Galaxy Outlaw

### DIFF
--- a/gamefixes/910830.py
+++ b/gamefixes/910830.py
@@ -1,0 +1,12 @@
+""" Game fix for Rebel Galaxy Outlaw
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ installs mfc42
+    """
+
+    # https://github.com/ValveSoftware/Proton/issues/4216
+    util.protontricks('mfc42')


### PR DESCRIPTION
mfc42 needs to be installed for the game to run. Tested with Proton 7.0-3