### PR TITLE
Added Darkest Hour: A Hearts of Iron Game fix

### DIFF
--- a/gamefixes/73170.py
+++ b/gamefixes/73170.py
@@ -1,5 +1,6 @@
 """ Game fix for Darkest Hour: A Hearts of Iron Game
 """
+#pylint: disable=C0103
 
 from protonfixes import util
 

--- a/gamefixes/73170.py
+++ b/gamefixes/73170.py
@@ -1,0 +1,11 @@
+""" Game fix for Darkest Hour: A Hearts of Iron Game
+"""
+
+from protonfixes import util
+
+def main():
+    """ Set virtual desktop
+    """
+
+    # https://github.com/ValveSoftware/Proton/issues/3338
+    util.protontricks('vd=1280x720')


### PR DESCRIPTION
I haven't done a protonfix PR before so hopefully this PR is ok, I tried to follow what was already in place.

I built Proton-GE with this change and it seemed to work correctly.

Essentially, using a virtual desktop for this game helps alleviate several issues like crashing, or graphical corruption.

For example, without using a virtual desktop, tabbing out and then back into the game causes issues like other open applications flickering on top of the game. This happens at least on my system (Fedora 36 Workstation, GTX 1080, Nvidia driver 515.57) and presumably on others as well.