### PR TITLE
origin_ge.verb: use silent switch

### DIFF
--- a/gamefixes/verbs/origin_ge.verb
+++ b/gamefixes/verbs/origin_ge.verb
@@ -6,7 +6,9 @@ w_metadata origin_ge dlls \
 
 load_origin_ge()
 {
-    w_download https://origin-a.akamaihd.net/Origin-Client-Download/origin/live/OriginThinSetup.exe e9349aaee26e5b4abfab8b8f829febd908554218e83e748cf624f29fc81ba0bc
+    w_download https://origin-a.akamaihd.net/Origin-Client-Download/origin/live/OriginThinSetup.exe
     w_try_cd "${W_CACHE}/${W_PACKAGE}"
-    w_try "${WINE}" start.exe /exec OriginThinSetup.exe /NoLaunch
+    w_try "${WINE}" start.exe /exec OriginThinSetup.exe /NoLaunch /SILENT
 }
+
+w_override_app_dlls origin.exe disabled gameux


### PR DESCRIPTION
The checksum changes often so don’t bother checking.

Disable gameux to avoid problems with registering games after they’ve been downloaded.