### PR TITLE
Add fix for GTA IV custom radio

### DIFF
--- a/gamefixes/12210.py
+++ b/gamefixes/12210.py
@@ -1,0 +1,11 @@
+""" Game fix for GTA IV
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ installs wmp11
+    """
+    # Fixes Independence FM user radio station
+    util.protontricks('wmp11')


### PR DESCRIPTION
Independence FM (the custom radio station that plays user-provided music) currently doesn't seem to work with proton.

Adding wmp11 mostly fixes it (there can be some corruption/silence after the first user track plays correctly, but eventually it fixes itself and seems to play fine after that).

fwiw I also looked a little into why it's not working out of the box, and I see gstreamer receiving and presumably decoding the mp3's in the logs, but I'm not sure where the disconnect is from there.