### PR TITLE
Add protonfix for Re-Volt (287310)

### DIFF
--- a/gamefixes/287310.py
+++ b/gamefixes/287310.py
@@ -1,0 +1,14 @@
+""" Game fix for Re-Volt (287310)
+"""
+
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ Sets the necessary dll overrides for the wrappers that are shipped with the game
+    """
+
+    # Set overrides
+    util.winedll_override('ddraw', 'n')
+    util.winedll_override('dinput', 'n')


### PR DESCRIPTION
Game needs proper dll overrides to work on newer Proton versions.
See: https://www.protondb.com/app/287310