### PR TITLE
fix(Fall Guys): executable change not needed

### DIFF
--- a/gamefixes/1097150.py
+++ b/gamefixes/1097150.py
@@ -15,8 +15,3 @@ def main():
         subprocess.call(['rm', '-rf', 'FallGuys_client_game_Data/Plugins/x86_64/easyanticheat_x64.so'])
     subprocess.call(['ln', '-s', '../../../EasyAntiCheat/easyanticheat_x64.so', 'FallGuys_client_game_Data/Plugins/x86_64/easyanticheat_x64.so'])
 
-    #Need to replace the command instead of the ini otherwise it will hang after installing EOS on new prefix
-    util.replace_command('FallGuys_client.exe', 'FallGuys_client_game.exe')
-    # Fixes the ini files.
-    #subprocess.call(['sed', '-i', 's/TargetApplicationPath=FallGuysEACLauncher.exe/TargetApplicationPath=FallGuys_client_game.exe/', 'FallGuys_client.ini'])
-


### PR DESCRIPTION
When we change the executable, the EOS fails to start. GE7-31 works, but G7-33 doesn't.