### PR TITLE
gamefixes: Assassins Creed Brotherhood | Battle Fantasia

### DIFF
--- a/gamefixes/356910.py
+++ b/gamefixes/356910.py
@@ -1,0 +1,18 @@
+"""
+Battle Fantasia Revised Edition
+
+This game was designed to run at 60 fps (as most fighting games), but it
+doesn't lock the frame rate in case your display refresh rate is higher
+than 60Hz.
+
+Related DXVK's issue: https://github.com/doitsujin/dxvk/issues/3145
+
+"""
+#pylint: disable=C0103
+import os
+
+def main():
+    # only set the frame limit in case it is not already defined
+    if "DXVK_FRAME_RATE" not in os.environ:
+        os.environ["DXVK_FRAME_RATE"] = "60"
+

--- a/gamefixes/48190.py
+++ b/gamefixes/48190.py
@@ -1,0 +1,10 @@
+""" Game fix for Assassin's Creed: Brotherhood
+
+Game uses an old customized Ubisoft launcher that's currently not working with Proton.
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    util.append_argument('-playoffline')


### PR DESCRIPTION
Assassin's Creed: Brotherhood
- This game uses an old customized Ubisoft launcher that's currently not working with Proton. The current workaround is to add the param `-playoffline`

Battle Fantasia: Revised Edition
- This game was designed to run at 60 fps (as most fighting games), but it
doesn't lock the frame rate in case your display refresh rate is higher
than 60Hz.