### PR TITLE
Fix multiplayer in old Stroghold games

### DIFF
--- a/gamefixes/16700.py
+++ b/gamefixes/16700.py
@@ -1,0 +1,14 @@
+""" Game fix for Stronghold Crusader Extreme HD
+Fixes Multiplayer
+"""
+
+# pylint: disable=C0103
+
+from protonfixes import util
+
+
+def main():
+    """ Installs directplay
+    """
+
+    util.protontricks('directplay')

--- a/gamefixes/40950.py
+++ b/gamefixes/40950.py
@@ -1,0 +1,13 @@
+""" Game fix for Stronghold HD
+Fixes Multiplayer
+"""
+# pylint: disable=C0103
+
+from protonfixes import util
+
+
+def main():
+    """ Installs directplay
+    """
+
+    util.protontricks('directplay')

--- a/gamefixes/40970.py
+++ b/gamefixes/40970.py
@@ -1,0 +1,14 @@
+""" Game fix for Stronghold Crusader HD
+Fixes Multiplayer
+"""
+
+# pylint: disable=C0103
+
+from protonfixes import util
+
+
+def main():
+    """ Installs directplay
+    """
+
+    util.protontricks('directplay')


### PR DESCRIPTION
This fixes multiplayer in the following games by adding directplay:
Stronghold HD, Stronghold Crusader HD and Stronghold Crusader Extreme HD