### PR TITLE
Add fix for Tokyo Necro

### DIFF
--- a/gamefixes/2183070.py
+++ b/gamefixes/2183070.py
@@ -4,8 +4,11 @@
 from protonfixes import util
 
 def main():
-    """ installs xact
+    """ installs xact, disable ESYNC, disable FSYNC
     """
 
-    # Fixes launch after typing then entering `search` within the game's terminal menu
+    # Fixes crash after typing then entering or clicking `search` within the game's terminal menu
     util.protontricks('xact')
+    # Fixes hanging after typing then entering or clicking `search` within the game's terminal menu
+    util.set_environment('PROTON_NO_ESYNC', '1')
+    util.set_environment('PROTON_NO_FSYNC', '1')

--- a/gamefixes/2183070.py
+++ b/gamefixes/2183070.py
@@ -1,0 +1,11 @@
+""" Game fix for Tokyo Necro
+"""
+
+from protonfixes import util
+
+def main():
+    """ installs xact
+    """
+
+    # Fixes launch after typing then entering `search` within the game's terminal menu
+    util.protontricks('xact')


### PR DESCRIPTION
Currently, installing _xact_ fixes the initial startup crash for the visual novel _Tokyo Necro_ after typing and entering search within the game's terminal menu.