### PR TITLE
Add fix for Outlaws + A Handful of Missions

### DIFF
--- a/gamefixes/559620.py
+++ b/gamefixes/559620.py
@@ -1,0 +1,12 @@
+""" Game fix for Outlaws + A Handful of Missions
+"""
+#pylint: disable=C0103
+#
+from protonfixes import util
+
+def main():
+    # Fix the (awesome) cutscenes.
+    util.protontricks('cnc_ddraw')
+
+    # Game ships with a WinMM replacement for CD music.
+    util.winedll_override('winmm', 'n,b')


### PR DESCRIPTION
Outlaws' cutscenes are borked by default.
https://bugs.winehq.org/show_bug.cgi?id=2082

Using `cnc_ddraw` fixes the cutscenes, and overriding `winmm` with `n,b` allows the music to work.