### PR TITLE
Fix Outlaws script, always test your stuff, lesson learned

### DIFF
--- a/gamefixes/559620.py
+++ b/gamefixes/559620.py
@@ -5,8 +5,5 @@
 from protonfixes import util
 
 def main():
-    # Fix the (awesome) cutscenes.
-    util.protontricks('cnc_ddraw')
-
-    # Game ships with a WinMM replacement for CD music.
-    util.winedll_override('winmm', 'n,b')
+    # Override ddraw (cutscenes+menu perf) and WinMM (Music)
+    util.set_environment('WINEDLLOVERRIDES', 'ddraw=n,b;winmm=n,b')


### PR DESCRIPTION
I just realized that Outlaws has its own `ddraw` that was works better, so let's use that.
Also `util.winedll_override` appears to not be working like it's supposed to.