### PR TITLE
[gamefixes] Carnage Cross (1795390)

### DIFF
--- a/gamefixes/1795390.py
+++ b/gamefixes/1795390.py
@@ -1,0 +1,9 @@
+""" Game fix for Carnage Cross
+Proton issue: https://github.com/ValveSoftware/Proton/issues/6645
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    util.replace_command("CarnageCross/CarnageCross", "CarnageCross/CarnageCross/Binaries/Win64/CarnageCross-Win64-Shipping.exe")


### PR DESCRIPTION
The game launch path is pointing to the directory instead of the executable (https://github.com/ValveSoftware/Proton/issues/6645)