### PR TITLE
Added fix for Megadimension Neptunia VII

### DIFF
--- a/gamefixes/460120.py
+++ b/gamefixes/460120.py
@@ -1,0 +1,12 @@
+""" Game fix for Megadimension Neptunia VII
+"""
+#pylint: disable=C0103
+#
+from protonfixes import util
+
+#Fixes cinematics not showing or spawning in a different window
+#also fixes cinematics not playing sound
+def main():
+    util.protontricks('quartz_feb2010')
+    util.protontricks('wmp11')
+    util.protontricks('qasf')


### PR DESCRIPTION
Hello,
game uses ASF codec for its cinematics and DirectShow to display them which isn't yet fully implemented it seems? The quartz-trick prevents the the cinematics from popping up in a new window. wmp11 comes with the asf codec and qasf was required to prevent the game from crashing by wmvcore (im not expert, I got this together by a lot of trial and error). This receipe was tested on GE-Proton-7-55 and Proton 8.0-1d which seem to have worked fine the first 20-30mins of playing from a fresh prefix. 

Hope this helps out the community and Steam Deck!

-Snaggly