### PR TITLE
[Gamefixes] Conception PLUS: Maidens of the Twelve Stars (906510) 

### DIFF
--- a/gamefixes/906510.py
+++ b/gamefixes/906510.py
@@ -1,0 +1,13 @@
+
+""" Game fix for Conception PLUS: Maidens of the Twelve Stars
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ installs d3dcompiler_47
+    """
+
+    # https://github.com/ValveSoftware/Proton/issues/3493#issuecomment-1521636321
+    util.protontricks('d3dcompiler_47')


### PR DESCRIPTION
Game crashes without having "d3dcompiler_47", tested fix with ProtonGE8-1 & Proton 7-0.6, worked fine for the time I played.
Hope this will help someone!