### PR TITLE
Fall Guys (1097150): Workaround for easyanticheat_x64.so removed

### DIFF
--- a/gamefixes/1097150.py
+++ b/gamefixes/1097150.py
@@ -1,8 +1,6 @@
 """ Game fix for Fall Guys
 """
 #pylint: disable=C0103
-import os
-import subprocess
 from protonfixes import util
 
 def main():
@@ -11,7 +9,4 @@ def main():
     util.install_eac_runtime()
     util.disable_esync()
     util.disable_fsync()
-    if os.path.exists('FallGuys_client_game_Data/Plugins/x86_64/easyanticheat_x64.so'):
-        subprocess.call(['rm', '-rf', 'FallGuys_client_game_Data/Plugins/x86_64/easyanticheat_x64.so'])
-    subprocess.call(['ln', '-s', '../../../EasyAntiCheat/easyanticheat_x64.so', 'FallGuys_client_game_Data/Plugins/x86_64/easyanticheat_x64.so'])
 


### PR DESCRIPTION
Location of easyanticheat_x64.so was fixed with update from 2023-05-10:
https://steamdb.info/depot/1097151/history/?changeid=M:2421232278122776259

https://steamdb.info/app/381210/info/ doesn't have an additional_depenendies entry containing EAC runtime, so manual installation is still needed.

Unnecessary imports removed