### PR TITLE
fixes for Shadows on the Vatican games (launching), The Blind Prophet (font issues) and Alter Ego (launching)

### DIFF
--- a/gamefixes/286360.py
+++ b/gamefixes/286360.py
@@ -1,0 +1,10 @@
+""" Shadows on the Vatican - Act I: Greed
+Launcher keeps it's process running in the background but nothing shows up
+"""
+#pylint: disable=C0103
+
+from protonfixes import util, os
+
+def main():
+    util.replace_command('SotV_Launcher.exe', 'hd/SotV1.exe')
+    os.chdir('hd') 

--- a/gamefixes/378630.py
+++ b/gamefixes/378630.py
@@ -1,0 +1,10 @@
+""" Shadows on the Vatican - Act II: Wrath
+Launcher keeps it's process running in the background but nothing shows up
+"""
+#pylint: disable=C0103
+
+from protonfixes import util, os
+
+def main():
+    util.replace_command('SotV_Launcher.exe', 'hd/SotV2.exe')
+    os.chdir('hd') 

--- a/gamefixes/63110.py
+++ b/gamefixes/63110.py
@@ -1,0 +1,11 @@
+""" Alter Ego
+Launcher crashes immediately without displaying any windows
+"""
+#pylint: disable=C0103
+
+from protonfixes import util, os
+
+def main():
+    util.replace_command('AlterEgo.exe', './RunDev.exe')
+    util.append_argument('AlterEgo.ebr')
+    util.set_environment('SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS', '0')    

--- a/gamefixes/968370.py
+++ b/gamefixes/968370.py
@@ -7,7 +7,4 @@ from protonfixes import util
 
 def main():
     util.set_environment('WINEDLLOVERRIDES', 'd3d9=d')
-    #util.append_argument('/NOF')
-    #util.set_environment('PROTON_USE_WINED3D9', '1')
-    #util.disable_dxvk()
-    util.protontricks('segoe_script5')
+    util.protontricks('segoe_script')

--- a/gamefixes/968370.py
+++ b/gamefixes/968370.py
@@ -1,0 +1,13 @@
+""" The Blind Prophet
+garbled fonts & No cursive font (Segoe Script)
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    util.set_environment('WINEDLLOVERRIDES', 'd3d9=d')
+    #util.append_argument('/NOF')
+    #util.set_environment('PROTON_USE_WINED3D9', '1')
+    #util.disable_dxvk()
+    util.protontricks('segoe_script5')

--- a/gamefixes/verbs/segoe_script.verb
+++ b/gamefixes/verbs/segoe_script.verb
@@ -1,0 +1,15 @@
+w_metadata segoe_script fonts \
+    title="Segoe Script font" \
+    publisher="Microsoft" \
+    year="2006" \
+    media="download" \
+    file1="SegoeScript.zip" \
+    installed_file1=${W_FONTSDIR_WIN}"/segoe script.ttf"
+
+load_segoe_script()
+{
+    w_download http://legionfonts.com/storage/archives/Segoe%20Script.zip e107150c98eabc93897616cccd6ab8ebd778a780ce69a31b5dd47f1991e90507 ${file1}
+    w_try_unzip "${W_TMP}" "${W_CACHE}/${W_PACKAGE}/${file1}"
+    w_try_cp_font_files "${W_TMP}" "${W_FONTSDIR_UNIX}" "*.ttf"
+    w_register_font "segoe script.ttf" "Segoe Script"
+}


### PR DESCRIPTION
### Shadows on the Vatican - Acts I & II
Launcher keeps it's process running in the background but nothing shows up.

- Execute the game directly instead of the launcher, previously changing the current directory to avoid missing files error.

### The Blind Prophet
Garbled fonts & No cursive font (Segoe Script)

- Override D3D9 (disable) to fix the garbled fonts.
- Made a verb segoe_script to have the correct cursive font instead of print (I'm torn on this, cursive is what it should be but the wrong one is more readable)
- Also there are characters missing (' " and accents but they are in the fonts, locale issue? tried changing lang but couldn't fix that)

### Alter Ego
Launcher crashes immediately without displaying any windows
- Replace launcher with engine launcher (Rundev.exe) and the game file (AlterEgo.ebr) as paremeter
- No minimize on focus loss so it doesn't start minimized