### PR TITLE
Add fix for APB Reloaded (113400)

### DIFF
--- a/gamefixes/113400.py
+++ b/gamefixes/113400.py
@@ -1,0 +1,9 @@
+""" APB Reloaded: Fix Wrong DLL error and Steam login crash
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    # Install Visual C++ Runtime 2017
+    util.protontricks('vcrun2017')


### PR DESCRIPTION
The game "APB Reloaded" crashes when logging in automatically via Steam if Visual C++ Runtime 2017 is not installed. 
Additionally, recent changes in the EXE packer cause a "Wrong DLL error" to be shown if said runtime is not available.