### PR TITLE
Fix for Two Worlds game on an audio bug

### DIFF
--- a/gamefixes/1930.py
+++ b/gamefixes/1930.py
@@ -1,0 +1,12 @@
+""" Two Worlds Epic Edition - ID 1930
+    https://www.protondb.com/app/1930
+"""
+
+from protonfixes import util
+
+def main():
+
+    util.protontricks('xact')
+
+
+


### PR DESCRIPTION
The Two Worlds game has a bug where the sound does not work with the libraries available in Wine. Requiring manual installation of the xact library.

This patch automates this.