### PR TITLE
Fix Neptunia Re;Birth 1 & 2 poor performance on some AMD hardware

### DIFF
--- a/gamefixes/282900.py
+++ b/gamefixes/282900.py
@@ -1,0 +1,10 @@
+""" Hyperdimension Neptunia Re;Birth1
+Poor performance on some AMD hardware
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    util.set_environment('radeonsi_disable_sam', 'true')
+    util.set_environment('AMD_DEBUG', 'nowc')

--- a/gamefixes/351710.py
+++ b/gamefixes/351710.py
@@ -1,0 +1,10 @@
+""" Hyperdimension Neptunia Re;Birth2
+Poor performance on some AMD hardware
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    util.set_environment('radeonsi_disable_sam', 'true')
+    util.set_environment('AMD_DEBUG', 'nowc') 


### PR DESCRIPTION
Hyperdimension Neptunia Re;Birth 1 & 2 have a performance bug on some AMD hardware. It can be fixed by setting some environment variables.

Original issue for more information
https://gitlab.freedesktop.org/mesa/mesa/-/issues/8176
