### PR TITLE
Fixes for Tex Murphy Overseer, Escape From Monkey Island, Memento Mori, Alternativa and more

### DIFF
--- a/gamefixes/1382330.py
+++ b/gamefixes/1382330.py
@@ -1,0 +1,11 @@
+""" Persona 5 Strikers
+Missing voices/sounds in cutscenes
+Requires disabling the gstreamer protonaudioconverterbin plugin to get full audio in cutscenes.
+fixed by Swish in Protondb
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    util.set_environment('GST_PLUGIN_FEATURE_RANK', 'protonaudioconverterbin:NONE')

--- a/gamefixes/1413480.py
+++ b/gamefixes/1413480.py
@@ -1,0 +1,11 @@
+""" Shin Megami Tensei III Nocturne HD Remaster
+Missing voices/sounds in cutscenes
+Requires disabling the gstreamer protonaudioconverterbin plugin to get full audio in cutscenes.
+fixed Persona 5 Strikers by Swish in Protondb
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    util.set_environment('GST_PLUGIN_FEATURE_RANK', 'protonaudioconverterbin:NONE')

--- a/gamefixes/200490.py
+++ b/gamefixes/200490.py
@@ -1,0 +1,14 @@
+""" Memento Mori
+wmp11 (Fixes missing logo videos and problems with working videos)
+replace launch command (workaround for ProtonGE since 8.4)
+hangs on logo without override
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    util.set_environment('WINEDLLOVERRIDES', 'libvkd3d-1=n')
+    util.replace_command('run_game.cmd', 'memento.exe')
+    util.append_argument('-lang:en,en')
+    util.protontricks('wmp11')

--- a/gamefixes/302370.py
+++ b/gamefixes/302370.py
@@ -1,0 +1,18 @@
+""" Tex Murphy: Overseer
+Digital Sound Initialization Error (Intel RSX 3D drivers are not installed)
+LAV Filters for video and DgVoodoo for textures
+edit registry to avoid ffdshow compatibility manager popup
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    util.protontricks('rsx3d')
+    if util.protontricks('lavfilters'):
+        util.regedit_add("HKEY_CURRENT_USER\\Software\\GNU\\ffdshow",'blacklist','REG_SZ','OVERSEER.EXE')
+        util.regedit_add("HKEY_CURRENT_USER\\Software\\GNU\\ffdshow_audio",'blacklist','REG_SZ','OVERSEER.EXE')
+    if util.protontricks('dgvoodoo2'):
+        import os, subprocess
+        syswow64 = os.path.join(util.protonprefix(), 'drive_c/windows/syswow64')
+        subprocess.call(["sed -i '/[DirectX]/ {{/Resolution/s/max/unforced/}}' {}{}".format(syswow64,'/dgvoodoo.conf')], shell=True)

--- a/gamefixes/33990.py
+++ b/gamefixes/33990.py
@@ -1,0 +1,11 @@
+""" Alternativa
+wmp11 (Fixes missing logo videos and problems with working videos)
+hangs on logo without override
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    util.set_environment('WINEDLLOVERRIDES', 'libvkd3d-1=n')
+    util.protontricks('wmp11')

--- a/gamefixes/409090.py
+++ b/gamefixes/409090.py
@@ -1,0 +1,16 @@
+""" The Big Secret of a Small Town
+No cursor or double cursor selecting custom cursor in options
+PROTON_USE_WINED3D=1 fixes the problem but removes the antialising
+dgvoodoo2 fixes the cursors and keeps the antialising
+copy dgvoodoo2 d3d9.dll every time otherwise it gets overwritten
+"""
+#pylint: disable=C0103
+
+import os, subprocess, shutil
+from protonfixes import util
+
+def main():
+    syswow64 = os.path.join(util.protonprefix(), 'drive_c/windows/syswow64')
+    if util.protontricks('dgvoodoo2'):
+        subprocess.call(["sed -i '/[DirectX]/ {{/Resolution/s/max/unforced/}}' {}{}".format(syswow64,'/dgvoodoo.conf')], shell=True)
+    shutil.copy(os.path.join(syswow64, 'dgd3d9.dll'),os.path.join(syswow64, 'd3d9.dll'))

--- a/gamefixes/730830.py
+++ b/gamefixes/730830.py
@@ -1,0 +1,12 @@
+""" Escape From Monkey Island
+replace launch command (workaround for ProtonGE since 8.4)
+dgvoodoo2 to force anti-aliasing and higher resolution
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    util.replace_command('start.bat', 'monkey4.exe')
+    util.replace_command('startConfig.bat', 'monkey.exe')
+    util.protontricks('dgvoodoo2')

--- a/gamefixes/verbs/dgvoodoo2.verb
+++ b/gamefixes/verbs/dgvoodoo2.verb
@@ -3,7 +3,7 @@ w_metadata dgvoodoo2 dlls \
     publisher="dege" \
     year="2023" \
     media="download" \
-    file1="dgVoodoo2_81.zip" \
+    file1="dgVoodoo2_81_1.zip" \
     installed_file1="${W_SYSTEM32_DLLS_WIN}/ddraw.dll" \
     installed_file2="${W_SYSTEM32_DLLS_WIN}/d3dimm.dll" \
     installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
@@ -12,7 +12,7 @@ w_metadata dgvoodoo2 dlls \
 
 load_dgvoodoo2()
 {
-    w_download https://github.com/dege-diosg/dgVoodoo2/releases/download/v2.81/dgVoodoo2_81.zip d1cd94aac9edb52ad5534c97a8866463ce4ff0293bf0737c81434bc9b0519624 ${file1}
+    w_download https://github.com/dege-diosg/dgVoodoo2/releases/download/v2.81.1/dgVoodoo2_81_1.zip 13c84b6e3b19bb5e38afdb67f2d1ee3c1b6291284a0043a6a40061d2c6e7c18c ${file1}
     w_try_unzip "${W_TMP}" "${W_CACHE}/${W_PACKAGE}/${file1}"
     w_try_cp_dll "${W_TMP}/MS/x86/DDraw.dll" "${W_SYSTEM32_DLLS}/ddraw.dll"
     w_try_cp_dll "${W_TMP}/MS/x86/D3DImm.dll" "${W_SYSTEM32_DLLS}/d3dimm.dll"

--- a/gamefixes/verbs/dgvoodoo2.verb
+++ b/gamefixes/verbs/dgvoodoo2.verb
@@ -1,0 +1,27 @@
+w_metadata dgvoodoo2 dlls \
+    title="dgvoodoo2" \
+    publisher="dege" \
+    year="2023" \
+    media="download" \
+    file1="dgVoodoo2_81.zip" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/ddraw.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/d3dimm.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/d3d9.dll" \
+    installed_file3="${W_SYSTEM32_DLLS_WIN}/dgd3d9.dll" \
+    installed_file4="${W_SYSTEM32_DLLS_WIN}/dgvoodoo.conf"
+
+load_dgvoodoo2()
+{
+    w_download https://github.com/dege-diosg/dgVoodoo2/releases/download/v2.81/dgVoodoo2_81.zip d1cd94aac9edb52ad5534c97a8866463ce4ff0293bf0737c81434bc9b0519624 ${file1}
+    w_try_unzip "${W_TMP}" "${W_CACHE}/${W_PACKAGE}/${file1}"
+    w_try_cp_dll "${W_TMP}/MS/x86/DDraw.dll" "${W_SYSTEM32_DLLS}/ddraw.dll"
+    w_try_cp_dll "${W_TMP}/MS/x86/D3DImm.dll" "${W_SYSTEM32_DLLS}/d3dimm.dll"
+    w_try_cp_dll "${W_TMP}/MS/x86/D3D9.dll" "${W_SYSTEM32_DLLS}/d3d9.dll"
+    w_try_cp_dll "${W_TMP}/MS/x86/D3D9.dll" "${W_SYSTEM32_DLLS}/dgd3d9.dll"
+    sed -i '/dgVoodooWatermark/s/true/false/' "${W_TMP}/dgVoodoo.conf"
+    sed -i '/[DirectX]/ {/Filtering/s/appdriven/16/ ; /KeepFilterIfPointSampled/s/false/true/ ; /Resolution/s/unforced/max/ ; /Antialiasing/s/appdriven/8x/}' "${W_TMP}/dgVoodoo.conf"
+    w_try_cp_dll "${W_TMP}/dgVoodoo.conf" "${W_SYSTEM32_DLLS}/dgvoodoo.conf"
+    w_override_dlls native ddraw
+    w_override_dlls native d3d9
+    w_override_dlls native d3dimm
+}

--- a/gamefixes/verbs/rsx3d.verb
+++ b/gamefixes/verbs/rsx3d.verb
@@ -1,0 +1,19 @@
+w_metadata rsx3d dlls \
+    title="Intel RSX 3D" \
+    publisher="Intel" \
+    year="1997" \
+    media="download" \
+    file1="rsx3d.zip" \
+    installed_file1="${W_SYSTEM32_DLLS_WIN}/rsx.dll" \
+    installed_file2="${W_SYSTEM32_DLLS_WIN}/aaudio.dll"
+
+load_rsx3d()
+{
+    w_download https://ilovepaws.nyc3.digitaloceanspaces.com/drivers/RSX3D.zip 1c931e4df0bcd435ce59f7fed5244efe14d84b97847315e4841998936c9afb20 ${file1}
+    w_try_unzip "${W_TMP}" "${W_CACHE}/${W_PACKAGE}/${file1}"
+    w_try_cp_dll "${W_TMP}/RSX3D/RSX.DLL" "${W_SYSTEM32_DLLS}/rsx.dll"
+    w_try_cp_dll "${W_TMP}/RSX3D/AAUDIO.DLL" "${W_SYSTEM32_DLLS}/aaudio.dll"
+    w_override_dlls native rsx aaudio
+    w_try_regsvr rsx.dll
+    w_try_regsvr aaudio.dll
+}


### PR DESCRIPTION
### BUG
I found a bug since 8.4 when launching .cmd and .bat for example in Escape from Monkey Island and Memento Mori (Workaround included in protonfixes, but not only for the launch bug, they need other fixes too)
i think it's because of this commit https://github.com/GloriousEggroll/proton-ge-custom/commit/44549b7679c00a418393059be743abbb31c57d07

### VERBS
- Intel RSX 3D drivers (Tex Murphy: Overseer)
- dgVoodoo2 (Tex Murphy: Overseer and others) 

### Tex Murphy: Overseer
- Digital Sound Initialization Error (Intel RSX 3D drivers are not installed)
- LAV Filters for video and DgVoodoo for textures
- edit registry to avoid ffdshow compatibility manager popup

### Escape From Monkey Island
- replace launch command (workaround for ProtonGE since 8.4)
- dgvoodoo2 to force anti-aliasing and higher resolution

### Memento Mori
- wmp11 (Fixes missing logo videos and problems with working videos)
- replace launch command (workaround for ProtonGE since 8.4)
- hangs on logo without override

### Alternativa
- wmp11 (Fixes missing logo videos and problems with working videos)
- hangs on logo without override

### The Big Secret of a Small Town
- No cursor or double cursor selecting custom cursor in options
- PROTON_USE_WINED3D=1 fixes the problem but removes the antialising dgvoodoo2 fixes the cursors and keeps the antialising
- copy dgvoodoo2 d3d9.dll every time otherwise it gets overwritten

The next two i don't have so i couldn't test.

### Persona 5 Strikers
- Missing voices/sounds in cutscenes
- Requires disabling the gstreamer protonaudioconverterbin plugin to get full audio in cutscenes.
- fixed by Swish in Protondb

### Shin Megami Tensei III Nocturne HD Remaster
- Missing voices/sounds in cutscenes
- Requires disabling the gstreamer protonaudioconverterbin plugin to get full audio in cutscenes.
- fixed Persona 5 Strikers by Swish in Protondb