### PR TITLE
Improve the Assetto Corsa experience

### DIFF
--- a/gamefixes/244210.py
+++ b/gamefixes/244210.py
@@ -5,9 +5,13 @@
 from protonfixes import util
 
 def main():
-    """ installs d3dcompiler_43,d3dx11_43, dotnet472
-    """
+    """Fixes default launcher and ACM."""
 
+    # Fixes Assetto itself and Content Manager. Version 4.5.2 does not seem to start.
+    # Although CefSharp from Content Manager might have a higher requirement, it seems to
+    # always crash on the GPU process so it doesn't really matter.
+    # NOTE: needs to come first as it wipes the prefix
+    util.protontricks_proton_5('dotnet472')  # seems to really need things from Proton 5 currently
+    # Fixes Content Manager (black windows)
     util.protontricks('d3dx11_43')
-    util.protontricks('d3dcompiler_43')
-    util.protontricks_proton_5('dotnet472')
+    util.protontricks('d3dcompiler_47')


### PR DESCRIPTION
Hi. This is based on using a recent Proton-GE. Between GE and Experimental my experience before was that it either would not start, or either only work with the default launcher or with the Content Manger. The result with this MR should be that a clean prefix will "just work" after a .NET install error. That is, it will work on second attempt, and both the original launcher and CM should be fine without any extra work like protontricks things and grabbing specific .NET executables.

Part of my issue was I didn't have Proton 5 installed and the result is silent failures since .NET won't install properly, so part of the PR is some improvement on that.

While figuring this out I stumbled on https://github.com/Winetricks/winetricks/pull/2101 and also noted GE's winetricks is quite old ? Just mentioning.