### PR TITLE
Disable protonaudioconverterbin in Atelier Marie Remake: The Alchemis…

### DIFF
--- a/gamefixes/2138090.py
+++ b/gamefixes/2138090.py
@@ -1,0 +1,12 @@
+""" Atelier Marie Remake: The Alchemist of Salburg
+Missing voices/sounds in cutscenes
+Requires disabling the gstreamer protonaudioconverterbin plugin to get full audio in cutscenes.
+fixed by Swish in Protondb
+further stolen from marianoag by bitwolf
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    util.set_environment('GST_PLUGIN_FEATURE_RANK', 'protonaudioconverterbin:NONE')


### PR DESCRIPTION
…t of Salburg

Taken from marianoag's work, fixes audio fine, supposedly an issue across a lot of the Atelier games but im unable to test those.