### PR TITLE
Restore audio in cutscenes in Atelier Ryza trilogy

### DIFF
--- a/gamefixes/1121560.py
+++ b/gamefixes/1121560.py
@@ -1,0 +1,11 @@
+""" Atelier Ryza: Ever Darkness & the Secret Hideout
+Missing voices/sounds in cutscenes
+Requires disabling the gstreamer protonaudioconverterbin plugin to get full audio in cutscenes
+"""
+
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    util.set_environment('GST_PLUGIN_FEATURE_RANK', 'protonaudioconverterbin:NONE')

--- a/gamefixes/1257290.py
+++ b/gamefixes/1257290.py
@@ -1,0 +1,11 @@
+""" Atelier Ryza 2: Lost Legends & the Secret Fairy
+Missing voices/sounds in cutscenes
+Requires disabling the gstreamer protonaudioconverterbin plugin to get full audio in cutscenes
+"""
+
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    util.set_environment('GST_PLUGIN_FEATURE_RANK', 'protonaudioconverterbin:NONE')

--- a/gamefixes/1999770.py
+++ b/gamefixes/1999770.py
@@ -1,0 +1,11 @@
+""" Atelier Ryza 3: Alchemist of the End & the Secret Key
+Missing voices/sounds in cutscenes
+Requires disabling the gstreamer protonaudioconverterbin plugin to get full audio in cutscenes
+"""
+
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    util.set_environment('GST_PLUGIN_FEATURE_RANK', 'protonaudioconverterbin:NONE')


### PR DESCRIPTION
Disable protonaudioconverterbin in order to restore the audio (inspired by Swish and stolen from Atelier Marie fix).