### PR TITLE
Correct Mafia 2 Definitive fix.

### DIFF
--- a/gamefixes/1030830.py
+++ b/gamefixes/1030830.py
@@ -5,8 +5,6 @@
 from protonfixes import util
 
 def main():
-    """ Launcherfix and NVIDIA PhysX support.
+    """ Enable NVIDIA PhysX support.
     """
-
-    # Fixes the startup process.
-    util.replace_command('Launcher.exe', '../Mafia II Definitive Edition.exe')
+    util.protontricks('physx')


### PR DESCRIPTION
Launcher fix is no longer needed, and the fix never did install physx, now it does.