### PR TITLE
Add physx protontricks to Batman Arkham Asylum

### DIFF
--- a/gamefixes/35140.py
+++ b/gamefixes/35140.py
@@ -11,6 +11,7 @@ def main():
     #Probably not needed when proton will be merged with newer wine
     util.protontricks('d3dcompiler_43')
     util.protontricks('d3dx9_43')
+    util.protontricks('physx')
     util._mk_syswow64() #pylint: disable=protected-access
 
 #TODO Controllers fixes


### PR DESCRIPTION
I will preface this PR by saying, I have no idea why this works, perhaps a library that's missing and is included with physx? I can't find a lot of information on this issue, so it seems to be pretty rare. I would prefer not to include physx to fix such a small graphical issue in the launcher, but I'm really not sure what actually fixes it.

Edit: There seems to be a community post on this issue, and others seem to fix it with PhysX / DirectX Runtime? - https://steamcommunity.com/app/35140/discussions/0/828925849552882800

This was removed with [this commit](https://github.com/GloriousEggroll/protonfixes/commit/13796d44faeee3fcc4657ebc9aba2604a549e129). However, this still resolves some text issues I encounter with the launcher.

Before:
![before](https://github.com/GloriousEggroll/protonfixes/assets/23139726/82cd7ce1-e90a-4c04-9407-575d49835924)

After:
![after](https://github.com/GloriousEggroll/protonfixes/assets/23139726/21c209db-1259-4d9d-a0b9-4305785c59a2)
