### PR TITLE
Fix broken audio in videos for Tokyo Necro

### DIFF
--- a/gamefixes/2183070.py
+++ b/gamefixes/2183070.py
@@ -12,3 +12,5 @@ def main():
     # Fixes hanging after typing then entering or clicking `search` within the game's terminal menu
     util.set_environment('PROTON_NO_ESYNC', '1')
     util.set_environment('PROTON_NO_FSYNC', '1')
+    # Fixes audio not playing for in-game videos
+    util.set_environment('GST_PLUGIN_FEATURE_RANK', 'protonaudioconverterbin:NONE')


### PR DESCRIPTION
Cleanly fixes the audio not playing for in-game videos via the `GST_PLUGIN_FEATURE_RANK` environment variable. 

To this date, the developers still hasn't fixed this problem and a popular reported workaround for this was to move Proton's media converter shared library file. 

Setting this variable eliminates the need for that.

https://www.protondb.com/app/2183070