### PR TITLE
Add Alan Wake gamefix: Fix launch error

### DIFF
--- a/gamefixes/108710.py
+++ b/gamefixes/108710.py
@@ -5,4 +5,8 @@ from protonfixes import util
 
 
 def main():
+    """ Installs d3dcompiler_47
+    """
+
+    # Fixes error on launch
     util.protontricks('d3dcompiler_47')

--- a/gamefixes/108710.py
+++ b/gamefixes/108710.py
@@ -1,0 +1,8 @@
+""" Alan Wake
+"""
+
+from protonfixes import util
+
+
+def main():
+    util.protontricks('d3dcompiler_47')


### PR DESCRIPTION
Fixes the `Constant "g_mLocalToClip" has an unknown class` error on launch.

![Screenshot_20231014_233818](https://github.com/GloriousEggroll/protonfixes/assets/23139726/84d549d9-1916-48a0-a392-99ac8a5bf02f)
