### PR TITLE
Add fix for NUKITASHI

### DIFF
--- a/gamefixes/2399220.py
+++ b/gamefixes/2399220.py
@@ -1,0 +1,11 @@
+""" Game fix for NUKITASHI
+"""
+
+from protonfixes import util
+
+def main():
+    """ Disable protonaudioconverterbin plugin
+    """
+
+    # Fixes audio not playing for in-game videos
+    util.set_environment('GST_PLUGIN_FEATURE_RANK', 'protonaudioconverterbin:NONE')


### PR DESCRIPTION
Fixes the audio not playing or being heard for in-game videos by using the `GST_PLUGIN_FEATURE_RANK` environment variable.

Proton-GE has already been (unofficially) reported to make videos work so with this fix, users should not have to take any additional steps such as messing with shared library files or setting environment variables.

https://www.protondb.com/app/2399220