### PR TITLE
Restore sound in The Great Ace Attorney Chronicles bonus videos

### DIFF
--- a/gamefixes/1158850.py
+++ b/gamefixes/1158850.py
@@ -1,0 +1,12 @@
+""" The Great Ace Attorney Chronicles
+Missing sound in bonus content videos
+Requires disabling the gstreamer protonaudioconverterbin to get full audio
+"""
+
+# pylint: disable=C0103
+
+from protonfixes import util
+
+
+def main():
+    util.set_environment("GST_PLUGIN_FEATURE_RANK", "protonaudioconverterbin:NONE")


### PR DESCRIPTION
This similar fix has been done to many other (Japanese) games using Windows Media Foundation.

Credit to Swish, marianoag, Bitwolfies and salixor for creating similar fixes previously.