### PR TITLE
Delete deprecated win32 helper functions

### DIFF
--- a/util.py
+++ b/util.py
@@ -149,25 +149,6 @@ def _killhanging():
         except IOError:
             continue
 
-def _del_syswow64():
-    """ Deletes the syswow64 folder
-    """
-
-    try:
-        shutil.rmtree(os.path.join(protonprefix(), 'drive_c/windows/syswow64'))
-    except FileNotFoundError:
-        log.warn('The syswow64 folder was not found')
-
-def _mk_syswow64():
-    """ Makes the syswow64 folder
-    """
-
-    try:
-        os.makedirs(os.path.join(protonprefix(), 'drive_c/windows/syswow64'))
-    except FileExistsError:
-        log.warn('The syswow64 folder already exists')
-
-
 def _forceinstalled(verb):
     """ Records verb into the winetricks.log.forced file
     """


### PR DESCRIPTION
Since commit https://github.com/GloriousEggroll/protonfixes/commit/6f019c8d84d3daeb2d03bec2492561f8858ec437 it is no longer possible to create 32-bit WINE prefixes, so these private helper functions are unnecessary.
