### PR TITLE
Delete DXVK async function

### DIFF
--- a/util.py
+++ b/util.py
@@ -430,9 +430,6 @@ def disable_nvapi():
 def disable_dxvk():  # pylint: disable=missing-docstring
     set_environment('PROTON_USE_WINED3D', '1')
 
-def enable_dxvk_async():  # pylint: disable=missing-docstring
-    set_environment('DXVK_ASYNC', '1')
-
 def disable_esync():  # pylint: disable=missing-docstring
     set_environment('PROTON_NO_ESYNC', '1')
 


### PR DESCRIPTION
Since GE-Proton7-45 DXVK async has been deprecated due to DXVK having implemented GraphicsPipelineLibrary (GPL). Therefore this function is unnecessary and should be deleted to discourage its use. 
