### PR TITLE
Restore audio in cutscenes in BlazBlue Centralfiction

### DIFF
--- a/gamefixes/586140.py
+++ b/gamefixes/586140.py
@@ -1,0 +1,11 @@
+""" BlazBlue Centralfiction
+Missing voices/sounds in cutscenes
+Requires disabling the gstreamer protonaudioconverterbin plugin to get full audio in cutscenes
+"""
+
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    util.set_environment('GST_PLUGIN_FEATURE_RANK', 'protonaudioconverterbin:NONE')


### PR DESCRIPTION
Disable protonaudioconverterbin in order to restore the audio (same as Atelier Marie/Ryza fixes).