### PR TITLE
Add helper for disabling protonaudioconverterbin

### DIFF
--- a/util.py
+++ b/util.py
@@ -439,6 +439,9 @@ def disable_esync():  # pylint: disable=missing-docstring
 def disable_fsync(): # pylint: disable=missing-docstring
     set_environment('PROTON_NO_FSYNC', '1')
 
+def disable_protonaudioconverter(): # pylint: disable=missing-docstring
+    set_environment('GST_PLUGIN_FEATURE_RANK', 'protonaudioconverterbin:NONE')
+
 def force_lgadd(): # pylint: disable=missing-docstring
     set_environment('PROTON_FORCE_LARGE_ADDRESS_AWARE', '1')
 


### PR DESCRIPTION
Currently, working around media playback issues may typically require setting the environment variable GST_PLUGIN_FEATURE_RANK=protonaudioconverterbin:NONE and this issue is already being explored in upstream WINE. 

To prevent possible runtime errors due to typos and for ease of use, centralize the usage via a short alias.

See https://bugs.winehq.org/show_bug.cgi?id=55596
