### PR TITLE
Added verb for xlive(less)

### DIFF
--- a/gamefixes/105400.py
+++ b/gamefixes/105400.py
@@ -1,67 +1,23 @@
 """ Game fix for Fable III
 """
+
 #pylint: disable=C0103
+
 import os
-import hashlib
-import urllib.request
-import multiprocessing
 import shutil
 
 from pathlib import Path
 from protonfixes import util
 from protonfixes.logger import log
 
-# https://www.reddit.com/r/SteamDeck/comments/vuagy2/finally_got_fable_3_working/
-xlive_url = "https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases/download/v4.68/Ultimate-ASI-Loader.zip"
-custom_xlivedll_sha256 = "baba99929487b005bb9b168acfd852550055f22e5f1059c9032765209bb185e5"
-
-
-def get_sha256(filepath: str) -> str:
-    try:
-        with open(filepath,"rb") as f:
-            return hashlib.sha256(f.read()).hexdigest();
-    except FileNotFoundError:
-        log(f"File '{filepath}' could not be found")
-
-
-def download_custom_xlive_dll():
-    xlive_path = f"{util.get_game_install_path()}/xlive.dll"
-    compressed_filepath = f"{util.get_game_install_path()}/xlive.zip"
-
-    if not os.path.exists(xlive_path):
-        if os.path.exists(compressed_filepath):
-            os.remove(compressed_filepath)
-
-        log("Downloading mocked 'xlive.dll'")
-        urllib.request.urlretrieve(xlive_url, compressed_filepath)
-
-        shutil.unpack_archive(compressed_filepath, extract_dir=util.get_game_install_path())
-
-        extracted_file = f"{util.get_game_install_path()}/dinput8.dll"
-
-        if get_sha256(extracted_file) != custom_xlivedll_sha256:
-            log("Mocked 'xlive.dll' has an unexpected checksum. It will be removed.")
-            os.remove(extracted_file)
-        else:
-            shutil.move(extracted_file, xlive_path)
-
-        os.remove(compressed_filepath)
-
-    else:
-        if get_sha256(xlive_path) != custom_xlivedll_sha256:
-            log("'xlive.dll' has an unexpected checksum. It will be redowloaded.")
-            os.remove(xlive_path)
-            download_custom_xlive_dll()  # try to redownload once
-
 
 def main():
-    try:
-        download_custom_xlive_dll()
-    except:
-        log("Unexpected exception when downloading mocked 'xlive.dll'")
+    # https://www.reddit.com/r/SteamDeck/comments/vuagy2/finally_got_fable_3_working/
+    util.protontricks("xliveless")
+
+    # Remove Windows Live folder
     dirpath = os.path.join(util.protonprefix(),"drive_c","Program Files","Common Files","Microsoft Shared","Windows Live")
     if os.path.exists(dirpath):
         shutil.rmtree(dirpath)
     else:
         log(f"Path '{dirpath}' could not be found")
-

--- a/gamefixes/12360.py
+++ b/gamefixes/12360.py
@@ -2,62 +2,11 @@
 This game requires GFWL, so a mocked 'xlive.dll' is required (multiplayer doesn't work, but single player does)
 
 """
+
 #pylint: disable=C0103
-import os
-import hashlib
-import urllib.request
-import multiprocessing
-import shutil
-from pathlib import Path
 
 from protonfixes import util
-from protonfixes.logger import log
-
-xlive_url = "https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases/download/v4.68/Ultimate-ASI-Loader.zip"
-custom_xlivedll_sha256 = "baba99929487b005bb9b168acfd852550055f22e5f1059c9032765209bb185e5"
-
-
-def get_sha256(filepath: str) -> str:
-    try:
-        with open(filepath,"rb") as f:
-            return hashlib.sha256(f.read()).hexdigest();
-    except FileNotFoundError:
-        log(f"File '{filepath}' could not be found")
-
-
-def download_custom_xlive_dll():
-    xlive_path = f"{util.get_game_install_path()}/xlive.dll"
-    compressed_filepath = f"{util.get_game_install_path()}/xlive.zip"
-
-    if not os.path.exists(xlive_path):
-        if os.path.exists(compressed_filepath):
-            os.remove(compressed_filepath)
-
-        log("Downloading mocked 'xlive.dll'")
-        urllib.request.urlretrieve(xlive_url, compressed_filepath)
-
-        shutil.unpack_archive(compressed_filepath, extract_dir=util.get_game_install_path())
-
-        extracted_file = f"{util.get_game_install_path()}/dinput8.dll"
-
-        if get_sha256(extracted_file) != custom_xlivedll_sha256:
-            log("Mocked 'xlive.dll' has an unexpected checksum. It will be removed.")
-            os.remove(extracted_file)
-        else:
-            shutil.move(extracted_file, xlive_path)
-
-        os.remove(compressed_filepath)
-
-    else:
-        if get_sha256(xlive_path) != custom_xlivedll_sha256:
-            log("'xlive.dll' has an unexpected checksum. It will be redowloaded.")
-            os.remove(xlive_path)
-            download_custom_xlive_dll()  # try to redownload once
 
 
 def main():
-    try:
-        download_custom_xlive_dll()
-    except:
-        log("Unexpected exception when downloading mocked 'xlive.dll'")
-
+    util.protontricks("xliveless")

--- a/gamefixes/45750.py
+++ b/gamefixes/45750.py
@@ -3,64 +3,17 @@ This game requires two fixes to work:
 1. A mocked xlive.dll for GFWL (multiplayer will not work, but the single player does)
 2. No more than 12 CPU cores (on PCGamingWiki is described as 6, but on my personal test I was able to set until 12 of 16) [source: https://www.pcgamingwiki.com/wiki/Lost_Planet_2#Alternate_solution_for_high_core_CPUs]
 """
+
 #pylint: disable=C0103
+
 import os
-import hashlib
-import urllib.request
 import multiprocessing
-import shutil
-from pathlib import Path
 
 from protonfixes import util
-from protonfixes.logger import log
-
-xlive_url = "https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases/download/v4.68/Ultimate-ASI-Loader.zip"
-custom_xlivedll_sha256 = "baba99929487b005bb9b168acfd852550055f22e5f1059c9032765209bb185e5"
-
-
-def get_sha256(filepath: str) -> str:
-    try:
-        with open(filepath,"rb") as f:
-            return hashlib.sha256(f.read()).hexdigest();
-    except FileNotFoundError:
-        log(f"File '{filepath}' could not be found")
-
-
-def download_custom_xlive_dll():
-    xlive_path = f"{util.get_game_install_path()}/xlive.dll"
-    compressed_filepath = f"{util.get_game_install_path()}/xlive.zip"
-
-    if not os.path.exists(xlive_path):
-        if os.path.exists(compressed_filepath):
-            os.remove(compressed_filepath)
-
-        log("Downloading mocked 'xlive.dll'")
-        urllib.request.urlretrieve(xlive_url, compressed_filepath)
-
-        shutil.unpack_archive(compressed_filepath, extract_dir=util.get_game_install_path())
-
-        extracted_file = f"{util.get_game_install_path()}/dinput8.dll"
-
-        if get_sha256(extracted_file) != custom_xlivedll_sha256:
-            log("Mocked 'xlive.dll' has an unexpected checksum. It will be removed.")
-            os.remove(extracted_file)
-        else:
-            shutil.move(extracted_file, xlive_path)
-
-        os.remove(compressed_filepath)
-
-    else:
-        if get_sha256(xlive_path) != custom_xlivedll_sha256:
-            log("'xlive.dll' has an unexpected checksum. It will be redowloaded.")
-            os.remove(xlive_path)
-            download_custom_xlive_dll()  # try to redownload once
 
 
 def main():
-    try:
-        download_custom_xlive_dll()
-    except:
-        log("Unexpected exception when downloading mocked 'xlive.dll'")
+    util.protontricks("xliveless")
 
     # the core fix is only applied if the user has not provided its own topology mapping
     if not os.getenv("WINE_CPU_TOPOLOGY"):

--- a/gamefixes/verbs/xliveless.verb
+++ b/gamefixes/verbs/xliveless.verb
@@ -1,0 +1,15 @@
+w_metadata xliveless dlls \
+    title="Games for Windows Live (gfw / gfwl) - xlive.dll mock, single player only" \
+    publisher="ThirteenAG" \
+    year="2022" \
+    media="download" \
+    file1="Ultimate-ASI-Loader.zip" \
+    installed_file1="xlive.dll"
+
+load_xliveless()
+{
+    w_download https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases/download/v4.68/Ultimate-ASI-Loader.zip 7517c7d5bd8c475f18e6545b7998df379eed6e2e0a19fcd2139669152f9bcddb ${file1}
+    w_try_unzip "${W_TMP}" "${W_CACHE}/${W_PACKAGE}/${file1}" "dinput8.dll"
+    w_try_cp_dll "${W_TMP}/dinput8.dll" "xlive.dll"
+    w_override_dlls native xlive
+}


### PR DESCRIPTION
Multiple fixes implemented (copy and paste) the same, extensive fix to download [xliveless](https://github.com/ThirteenAG/Ultimate-ASI-Loader/tree/master/source/xlive).

I experimented with creating a verb for it, I don't own any of the related games though.
However, I tested the verb with a different game and the `xlive.dll` is actually in the games folder, just like with the current solution.

Feedback is welcome. I think this solution is (c)leaner.

EDIT: Only difference that comes to mind is, the file is not checked on every start.