### PR TITLE
Game fix for Fallout 76

### DIFF
--- a/gamefixes-Steam/1151340.py
+++ b/gamefixes-Steam/1151340.py
@@ -1,0 +1,9 @@
+""" Game fix for Fallout 76
+"""
+#pylint: disable=C0103
+from protonfixes import util
+
+def main():
+    """ Ensure Faudio is installed so UI and NPC audio and music is audible
+    """
+    util.protontricks('faudio')


### PR DESCRIPTION
Ensure Faudio is installed so that user interface and NPC audio, and music is audible.